### PR TITLE
initial peer dependancies of three and urdf-loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,9 +23,7 @@
   "dependencies": {
     "gl-matrix": "^3.3.0",
     "linear-solve": "^1.2.1",
-    "svd-js": "^1.1.1",
-    "three": "^0.120.1",
-    "urdf-loader": "^0.9.1"
+    "svd-js": "^1.1.1"
   },
   "devDependencies": {
     "@babel/core": "^7.11.6",
@@ -35,7 +33,13 @@
     "eslint-plugin-jest": "^24.1.0",
     "jest": "^26.4.2",
     "jest-cli": "^26.4.2",
-    "parcel-bundler": "^1.12.4"
+    "parcel-bundler": "^1.12.4",
+    "three": "^0.120.1",
+    "urdf-loader": "^0.9.1"
+  },
+  "peerDependencies": {
+    "three": "^0.120.1",
+    "urdf-loader": "^0.9.1"
   },
   "license": "Apache-2.0"
 }

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -1,0 +1,16 @@
+import { Link } from './Link.js';
+import { Joint, DOF, DOF_NAMES } from './Joint.js';
+import { Goal } from './Goal.js';
+import { Solver } from './Solver.js';
+import { SOLVE_STATUS, SOLVE_STATUS_NAMES } from './ChainSolver.js';
+
+export {
+	Link,
+	Joint,
+	Goal,
+	Solver,
+	DOF,
+	DOF_NAMES,
+	SOLVE_STATUS,
+	SOLVE_STATUS_NAMES,
+};

--- a/src/worker/index.js
+++ b/src/worker/index.js
@@ -1,0 +1,5 @@
+import { WorkerSolver } from './WorkerSolver.js';
+
+export {
+	WorkerSolver,
+};


### PR DESCRIPTION
Here is a naive first pass at removing deps on three and urdf-loader by default and making them optional peer dependancies.

npm run start compiled but automatically readded the dependancies to package.json...

Input welcome on improving this. 