### PR TITLE
Track closure joints on links

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,6 +345,14 @@ _extends [Frame](#Frame)_
 
 A [Frame](#Frame) modeling a fixed connection between two [Joints](#Joint). Only [Joints](#Joint) may be added as children.
 
+### .closureJoints
+
+```js
+closureJoints : Array<Joint>
+```
+
+The set of joints that are connected to this indirectly via `Joint.makeClosure`.
+
 ## Joint
 
 _extends [Frame](#Frame)_
@@ -503,6 +511,8 @@ makeClosure( child : Link ) : void
 
 Declares the relationship between this joint and the given child link is a closure meaning there is no direct parent child relationship but the [Solver](#Solver) will treat the closure link as a target for this joint to keep them closed.
 
+Note that when making a closure connection between a Joint and a Link the link will not be added to the Joints `children` array and instead will only be available on the `child` field. The Joint will be appended to the Links `closureJoints` array.
+
 ## Goal
 
 _extends [Joint](#Joint)_
@@ -563,7 +573,7 @@ rotationErrorClamp = 0.1;
 roots : Array<Frame>
 ```
 
-The list of roots that should be accounted for in a solve. Note that if a closure joint is not traversable from a root then it or one of its parents must be included in the list of roots.
+The list of roots that should be accounted for in a solve. When `.updateStructure` is called the series of roots are traversed including closure joints to find all connected link hierarchies to use in the solve.
 
 ### .constructor
 
@@ -655,7 +665,7 @@ A helper class for rendering the joints and links in a three.js scene. Renders f
 roots : Array<Frame>
 ```
 
-Set of roots to render in the helper visualization. If this is changed then `.update` must be called.
+Set of roots to render in the helper visualization. If this is changed then `.updateStructure` must be called.
 
 ### .constructor
 

--- a/README.md
+++ b/README.md
@@ -531,7 +531,7 @@ divergeThreshold = 0.01;
 // The fixed damping factor to use in the DLS calculation.
 dampingFactor = 0.001;
 
-// The factor with which to move the joints towards the rest pose if set. 
+// The factor with which to move the joints towards the rest pose if set.
 restPoseFactor = 0.01;
 
 // The thresholds with which to compute whether or not the translation or rotation
@@ -681,10 +681,10 @@ setResolution( width : Number, height : Number ) : void
 
 Sets the resolution of the renderer so the 2d lines can be rendered at the appropriate thickness.
 
-### .update
+### .updateStructure
 
 ```js
-update() : void
+updateStructure() : void
 ```
 
 Must be called if the structure of the IK system being visualized has changed.

--- a/README.md
+++ b/README.md
@@ -133,7 +133,15 @@ An array of strings representing the names of the above solve statuses.
 
 ## Functions
 
-Set of functions for creating an ik system from and working with results from [URDFLoader](https://github.com/gkjohnson/urdf-loaders/tree/master/javascript).
+Set of utility functions including some for creating an ik system from and working with results from [URDFLoader](https://github.com/gkjohnson/urdf-loaders/tree/master/javascript).
+
+### findRoots
+
+```js
+findRoots( frames : Array<Frame> ) : Array<Frame>
+```
+
+Takes an array of frames to traverse including the closure joints and links and finds a set of unique nodes to treat as the roots of the connected trees for use in solving.
 
 ### urdfRobotToIKRoot
 

--- a/example/goals.js
+++ b/example/goals.js
@@ -153,7 +153,7 @@ function init() {
 	} );
 	scene.add( ikHelper );
 
-	solver = new Solver( [ ikRoot, goal ] );
+	solver = new Solver( ikRoot );
 	Object.assign( solver, solverOptions );
 
 	function updateGoalDoF() {

--- a/example/index.js
+++ b/example/index.js
@@ -664,7 +664,7 @@ function loadModel( promise ) {
 			ik.updateMatrixWorld( true );
 
 			// create the helper
-			ikHelper = new IKRootsHelper( [ ik ] );
+			ikHelper = new IKRootsHelper( ik );
 			ikHelper.setJointScale( helperScale );
 			ikHelper.setResolution( window.innerWidth, window.innerHeight );
 			ikHelper.traverse( c => {
@@ -677,7 +677,7 @@ function loadModel( promise ) {
 
 			} );
 
-			drawThroughIkHelper = new IKRootsHelper( [ ik ] );
+			drawThroughIkHelper = new IKRootsHelper( ik );
 			drawThroughIkHelper.setJointScale( helperScale );
 			drawThroughIkHelper.setResolution( window.innerWidth, window.innerHeight );
 			drawThroughIkHelper.traverse( c => {
@@ -705,7 +705,7 @@ function loadModel( promise ) {
 
 			} );
 
-			solver = params.webworker ? new WorkerSolver( [ ik, ...loadedGoals ] ) : new Solver( [ ik, ...loadedGoals ] );
+			solver = params.webworker ? new WorkerSolver( ik ) : new Solver( ik );
 			solver.maxIterations = 3;
 			solver.translationErrorClamp = 0.25;
 			solver.rotationErrorClamp = 0.25;

--- a/src/core/Joint.js
+++ b/src/core/Joint.js
@@ -611,6 +611,7 @@ export class Joint extends Frame {
 			this.children[ 0 ] = child;
 			this.child = child;
 			this.isClosure = true;
+			child.closureJoints.push( this );
 
 		}
 
@@ -645,6 +646,9 @@ export class Joint extends Frame {
 				this.children.length = 0;
 				this.child = null;
 				this.isClosure = false;
+
+				const index = child.closureJoints.indexOf( this );
+				child.closureJoints.splice( index, 1 );
 
 			}
 

--- a/src/core/Joint.js
+++ b/src/core/Joint.js
@@ -602,7 +602,7 @@ export class Joint extends Frame {
 	// Add child overrides
 	makeClosure( child ) {
 
-		if ( ! child.isLink || this.children.length >= 1 || child.parent === this ) {
+		if ( ! child.isLink || this.child || child.parent === this ) {
 
 			throw new Error();
 
@@ -620,7 +620,7 @@ export class Joint extends Frame {
 
 	addChild( child ) {
 
-		if ( ! child.isLink || this.children.length >= 1 || child.parent === this ) {
+		if ( ! child.isLink || this.child || child.parent === this ) {
 
 			throw new Error();
 

--- a/src/core/Joint.js
+++ b/src/core/Joint.js
@@ -608,7 +608,8 @@ export class Joint extends Frame {
 
 		} else {
 
-			this.children[ 0 ] = child;
+			// don't store the closure child in the children array to avoid
+			// implicit traversal.
 			this.child = child;
 			this.isClosure = true;
 			child.closureJoints.push( this );
@@ -643,7 +644,6 @@ export class Joint extends Frame {
 
 			} else {
 
-				this.children.length = 0;
 				this.child = null;
 				this.isClosure = false;
 

--- a/src/core/Link.js
+++ b/src/core/Link.js
@@ -6,6 +6,7 @@ export class Link extends Frame {
 
 		super();
 		this.isLink = true;
+		this.closureJoints = [];
 
 	}
 

--- a/src/core/Solver.js
+++ b/src/core/Solver.js
@@ -1,4 +1,5 @@
 import { ChainSolver } from './ChainSolver.js';
+import { findRoots } from './utils/findRoots.js';
 
 export class Solver {
 
@@ -32,7 +33,7 @@ export class Solver {
 	// needs to be called whenever tree structure is updated
 	updateStructure() {
 
-		const roots = this.roots;
+		const roots = findRoots( this.roots );
 		const chains = [];
 		const traversal = new Set();
 		const allChainJoints = new Set();

--- a/src/core/utils/findRoots.js
+++ b/src/core/utils/findRoots.js
@@ -1,0 +1,53 @@
+export function findRoots( frames ) {
+
+	const roots = [];
+	const set = new Set();
+
+	frames.forEach( frame => {
+
+		if ( set.has( frame ) ) {
+
+			return;
+
+		}
+
+		roots.push( frame );
+		frame.traverse( c => {
+
+			if ( set.has( c ) ) {
+
+				return true;
+
+			}
+
+			set.add( c );
+
+			if ( c.isLink ) {
+
+				const closureJoints = c.closureJoints;
+				closureJoints.forEach( joint => {
+
+					let lastParent = joint;
+					joint.traverseParents( p => {
+
+						lastParent = p;
+
+					} );
+
+					if ( ! set.has( lastParent ) ) {
+
+						roots.push( lastParent );
+
+					}
+
+				} );
+
+			}
+
+		} );
+
+	} );
+
+	return roots;
+
+}

--- a/src/core/utils/findRoots.js
+++ b/src/core/utils/findRoots.js
@@ -1,13 +1,18 @@
 export function findRoots( frames ) {
 
+	const potentialRoots = [ ...frames ];
 	const roots = [];
 	const set = new Set();
 
-	frames.forEach( frame => {
+	for ( let i = 0; i < potentialRoots.length; i ++ ) {
 
+		const frame = potentialRoots[ i ];
+
+		// If this frame has already been traversed then we know it's in
+		// a root already.
 		if ( set.has( frame ) ) {
 
-			return;
+			continue;
 
 		}
 
@@ -22,13 +27,26 @@ export function findRoots( frames ) {
 
 			set.add( c );
 
+			// If we come across a joint or link with closures traverse them
+			// as far as possible to add them to the roots if they haven't been
+			// added already.
+			let closureConnections;
 			if ( c.isLink ) {
 
-				const closureJoints = c.closureJoints;
-				closureJoints.forEach( joint => {
+				closureConnections = c.closureJoints;
 
-					let lastParent = joint;
-					joint.traverseParents( p => {
+			} else if ( c.isJoint && c.isClosure ) {
+
+				closureConnections = [ c.child ];
+
+			}
+
+			if ( closureConnections ) {
+
+				closureConnections.forEach( cl => {
+
+					let lastParent = cl;
+					cl.traverseParents( p => {
 
 						lastParent = p;
 
@@ -36,7 +54,7 @@ export function findRoots( frames ) {
 
 					if ( ! set.has( lastParent ) ) {
 
-						roots.push( lastParent );
+						potentialRoots.push( lastParent );
 
 					}
 
@@ -46,7 +64,7 @@ export function findRoots( frames ) {
 
 		} );
 
-	} );
+	}
 
 	return roots;
 

--- a/src/core/utils/findRoots.js
+++ b/src/core/utils/findRoots.js
@@ -1,6 +1,16 @@
 export function findRoots( frames ) {
 
-	const potentialRoots = [ ...frames ];
+	const potentialRoots = frames.map( f => {
+
+		let lastParent = f;
+		f.traverseParents( p => {
+
+			lastParent = p;
+
+		} );
+		return lastParent;
+
+	} );
 	const roots = [];
 	const set = new Set();
 

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ import { SOLVE_STATUS, SOLVE_STATUS_NAMES } from './core/ChainSolver.js';
 import { WorkerSolver } from './worker/WorkerSolver.js';
 import { IKRootsHelper } from './three/IKRootsHelper.js';
 import { setIKFromUrdf, setUrdfFromIK, urdfRobotToIKRoot } from './three/urdfHelpers.js';
+import { findRoots } from './core/utils/findRoots.js';
 
 export {
 	Link,
@@ -22,4 +23,5 @@ export {
 	setIKFromUrdf,
 	setUrdfFromIK,
 	urdfRobotToIKRoot,
+	findRoots,
 };

--- a/src/three/IKRootsHelper.js
+++ b/src/three/IKRootsHelper.js
@@ -13,7 +13,7 @@ export class IKRootsHelper extends Group {
 		this.joints = new Map();
 		this.links = new Map();
 		this.resolution = new Vector2( 1000, 1000 );
-		this.update();
+		this.updateStructure();
 
 	}
 
@@ -46,7 +46,7 @@ export class IKRootsHelper extends Group {
 
 	}
 
-	update() {
+	updateStructure() {
 
 		const { roots, joints, links } = this;
 

--- a/src/three/IKRootsHelper.js
+++ b/src/three/IKRootsHelper.js
@@ -1,6 +1,7 @@
 import { Group, Vector2 } from 'three';
 import { IKJointHelper } from './IKJointHelper.js';
 import { IKLinkHelper } from './IKLinkHelper.js';
+import { findRoots } from '../core/utils/findRoots.js';
 
 const currLinks = new Set();
 const currJoints = new Set();
@@ -48,7 +49,9 @@ export class IKRootsHelper extends Group {
 
 	updateStructure() {
 
-		const { roots, joints, links } = this;
+		const { joints, links } = this;
+
+		const roots = findRoots( this.roots );
 
 		currJoints.clear();
 		joints.forEach( ( helper, joint ) => currJoints.add( joint ) );

--- a/src/worker/WorkerSolver.js
+++ b/src/worker/WorkerSolver.js
@@ -7,6 +7,7 @@ import {
 	copyBufferToFrame,
 	JOINT_STRIDE,
 } from './utils.js';
+import { findRoots } from '../core/utils/findRoots.js';
 
 export class WorkerSolver {
 
@@ -74,7 +75,9 @@ export class WorkerSolver {
 	// changes or a degree of freedom changes. Or if the main thread must change the DoF values.
 	updateStructure() {
 
-		const { roots, worker } = this;
+		const { worker } = this;
+
+		const roots = findRoots( this.roots );
 
 		// Get all frames in the graph
 		const framesSet = new Set();

--- a/src/worker/WorkerSolver.js
+++ b/src/worker/WorkerSolver.js
@@ -11,7 +11,7 @@ import { findRoots } from '../core/utils/findRoots.js';
 
 export class WorkerSolver {
 
-	constructor( roots ) {
+	constructor( roots = [] ) {
 
 		this.roots = Array.isArray( roots ) ? [ ...roots ] : [ roots ];
 		this.status = [];

--- a/src/worker/serialize.js
+++ b/src/worker/serialize.js
@@ -55,6 +55,7 @@ export function serialize( frames ) {
 			quaternion: quaternion.slice(),
 			children: null,
 			closureJoints: null,
+			child: null,
 			type,
 		};
 
@@ -72,6 +73,12 @@ export function serialize( frames ) {
 		if ( frame.isLink ) {
 
 			inf.closureJoints = frame.closureJoints.map( c => map.get( c ) );
+
+		}
+
+		if ( frame.isJoint && frame.child ) {
+
+			inf.child = map.get( info.child );
 
 		}
 
@@ -164,7 +171,7 @@ export function deserialize( data ) {
 
 		if ( frame.isJoint ) {
 
-			frame.child = frame.children[ 0 ] || null;
+			frame.child = info.child !== null ? frames[ info.child ] : null;
 			frame.setMatrixDoFNeedsUpdate();
 
 		}

--- a/src/worker/serialize.js
+++ b/src/worker/serialize.js
@@ -78,7 +78,7 @@ export function serialize( frames ) {
 
 		if ( frame.isJoint && frame.child ) {
 
-			inf.child = map.get( info.child );
+			inf.child = map.get( frame.child );
 
 		}
 

--- a/src/worker/serialize.js
+++ b/src/worker/serialize.js
@@ -71,7 +71,7 @@ export function serialize( frames ) {
 		inf.children = frame.children.map( c => map.get( c ) );
 		if ( frame.isLink ) {
 
-			inf.closureJoints = frame.map( c => map.get( c ) );
+			inf.closureJoints = frame.closureJoints.map( c => map.get( c ) );
 
 		}
 

--- a/src/worker/serialize.js
+++ b/src/worker/serialize.js
@@ -54,6 +54,7 @@ export function serialize( frames ) {
 			position: position.slice(),
 			quaternion: quaternion.slice(),
 			children: null,
+			closureJoints: null,
 			type,
 		};
 
@@ -68,6 +69,11 @@ export function serialize( frames ) {
 		const inf = info[ i ];
 		const frame = frames[ i ];
 		inf.children = frame.children.map( c => map.get( c ) );
+		if ( frame.isLink ) {
+
+			inf.closureJoints = frame.map( c => map.get( c ) );
+
+		}
 
 		if ( frame.parent ) {
 
@@ -149,6 +155,12 @@ export function deserialize( data ) {
 		frame.parent = frames[ info.parent ] || null;
 		frame.children.push( ...info.children.map( i => frames[ i ] ) );
 		frame.setMatrixNeedsUpdate();
+
+		if ( frame.isLink ) {
+
+			frame.closureJoints.push( ...info.closureJoints.map( i => frames[ i ] ) );
+
+		}
 
 		if ( frame.isJoint ) {
 

--- a/test/core/Joint.test.js
+++ b/test/core/Joint.test.js
@@ -1,5 +1,6 @@
 import { Link } from '../../src/core/Link.js';
 import { Joint, DOF } from '../../src/core/Joint.js';
+import { findRoots } from '../../src/core/utils/findRoots.js';
 
 describe( 'Joint', () => {
 
@@ -308,6 +309,33 @@ describe( 'Joint', () => {
 
 			expect( child.closureJoints ).toEqual( [ joint ] );
 			expect( caught ).toBeTruthy();
+
+		} );
+
+	} );
+
+	describe( 'findRoots', () => {
+
+		it( 'should find roots of connected closure joints.', () => {
+
+			const joint = new Joint();
+			const parent = new Link();
+			const closureChild = new Link();
+
+			const joint2 = new Joint();
+			const closureChild2 = new Link();
+
+			parent.addChild( joint );
+			joint.makeClosure( closureChild );
+
+			closureChild.addChild( joint2 );
+			joint2.makeClosure( closureChild2 );
+
+			const roots = findRoots( [ parent ] );
+			expect( roots ).toEqual( [ parent, closureChild, closureChild2 ] );
+
+			const roots2 = findRoots( [ closureChild ] );
+			expect( roots2 ).toEqual( [ closureChild, parent, closureChild2 ] );
 
 		} );
 

--- a/test/core/Joint.test.js
+++ b/test/core/Joint.test.js
@@ -216,6 +216,7 @@ describe( 'Joint', () => {
 
 			expect( joint.isClosure ).toEqual( true );
 			expect( joint.child ).toEqual( child );
+			expect( child.closureJoints ).toEqual( [ joint ] );
 
 		} );
 
@@ -261,6 +262,7 @@ describe( 'Joint', () => {
 
 			}
 
+			expect( child.closureJoints ).toEqual( [] );
 			expect( caught ).toBeTruthy();
 
 		} );
@@ -275,10 +277,13 @@ describe( 'Joint', () => {
 			const child = new Link();
 
 			joint.makeClosure( child );
+			expect( child.closureJoints ).toEqual( [ joint ] );
+
 			joint.removeChild( child );
 
 			expect( joint.isClosure ).toEqual( false );
 			expect( joint.child ).toEqual( null );
+			expect( child.closureJoints ).toEqual( [] );
 
 		} );
 
@@ -301,6 +306,7 @@ describe( 'Joint', () => {
 
 			}
 
+			expect( child.closureJoints ).toEqual( [ joint ] );
 			expect( caught ).toBeTruthy();
 
 		} );


### PR DESCRIPTION
Fix #49

How should traversal work? We need to find all the connected roots for traversal in the IK helper and solver.
- Provide an option to `traverse` to continue down closure joints?
- Provide a second argument to `traverse` and `traverseParents` that indicates already traversed nodes? This can at least be used to find the roots of connected trees.

### Changed
- Joints no longer store closure links in the `children` array.

### TODO

- [ ] ~Traverse closure joints in `traverse` function?~
- [x] Update examples to not require passing all roots and children even if they're connected by a closure
- [x] Find all roots in helper visualization
- [x] Find all roots in solver
- [x] Find all roots in worker solver
- [x] Serialize tests stalling
- [x] Update find roots to traverse to the parents
- [x] Update docs
    - [x] Expose and document `findRoots` util
    - [x] Update helper and solver docs to indicate you don't need to pass roots in yourself
    - [x] Update docs indicating that joint does not store closure links in the children array
- [x] Rename `IKRootsHelper.update` -> `IKRootsHelper.updateStructure`.
- [x] Add `findRoots` function for finding all roots of connected systems.
- [x] Add tests
- [x] Update serialization, deserialization
