### PR TITLE
Fix: ts definition: Frame's parent can be undefined

### DIFF
--- a/src/core/Frame.d.ts
+++ b/src/core/Frame.d.ts
@@ -7,7 +7,7 @@ export class Frame {
 	matrix : Float32Array;
 	matrixWorld : Float32Array;
 
-	parent? : Frame;
+	parent : Frame | null;
 	children : Array<Frame>;
 
 	setPosition( x : Number, y : Number, z : Number ) : void;

--- a/src/core/Frame.d.ts
+++ b/src/core/Frame.d.ts
@@ -7,7 +7,7 @@ export class Frame {
 	matrix : Float32Array;
 	matrixWorld : Float32Array;
 
-	parent : Frame;
+	parent? : Frame;
 	children : Array<Frame>;
 
 	setPosition( x : Number, y : Number, z : Number ) : void;


### PR DESCRIPTION
Frame's parent can be undefined for root, or a closure (Goal).