### PR TITLE
Faster "rest pose" calculations

### DIFF
--- a/src/core/ChainSolver.js
+++ b/src/core/ChainSolver.js
@@ -423,6 +423,9 @@ export class ChainSolver {
 
 				}
 
+				// Nullspace projection: "restPose - J^-1 * (J * restPose)" which is mathematically
+				// equivalent to "(I - J^-1 * J) * restPose". This version avoids constructing and
+				// performing a freeDoF x freeDoF multiplication needed for the identity calculations.
 
 				// J * restPose > errorRows x 1
 				const jRestPose = matrixPool.get( errorRows, 1 );


### PR DESCRIPTION
Related to #131

This simplifies the calculations and avoids needing to a complex multiplication operation with an identity matrix.

**Before**

jij = J^-1 * J
nullspaceproj = I - jij
result = ( I - J^-1 * J ) * restPose

**After**

jRestPos = J * restPos
result = restPos - J^-1 * jRestPos
